### PR TITLE
Update CSRF scan to check session.secure instead of session.secure_co…

### DIFF
--- a/src/Lang/pt-br.json
+++ b/src/Lang/pt-br.json
@@ -51,8 +51,8 @@
 
     "CSRF Scanner": "Verificação do CSRF",
     "Verifying CSRF...": "Verificando configuração do CSRF",
-    "session.secure_cookie is disabled. Enable it for aditional security": "session.secure_cookie não está habilitado. Habilite para segurança adicional.",
-    "session.secure_cookie is enabled": "session.secure_cookie está habilitado",
+    "session.secure is disabled. Enable it for aditional security": "session.secure não está habilitado. Habilite para segurança adicional.",
+    "session.secure is enabled": "session.secure está habilitado",
     "session.same_site not defined. Set it to `strict` or `lax`": "session.same_site não foi configurado. Configure para `strict` ou `lax`",
     "session.same_site well configured: :same_site": "session.same_site configurado corretamente: :same_site",
 

--- a/src/Scanners/CsrfScan.php
+++ b/src/Scanners/CsrfScan.php
@@ -10,10 +10,10 @@ final class CsrfScan extends AbstractScanner implements ScannerInterface
     {
         $this->info(self::CHECK . __("Verifying CSRF..."));
 
-        if (!config('session.secure_cookie')) {
-            $this->warn(self::WARNING . __("session.secure_cookie is disabled. Enable it for aditional security"));
+        if (!config('session.secure')) {
+            $this->warn(self::WARNING . __("session.secure is disabled. Enable it for aditional security"));
         } else {
-            $this->info(self::CHECK . __("session.secure_cookie is enabled"));
+            $this->info(self::CHECK . __("session.secure is enabled"));
         }
 
         if (!config('session.same_site')) {


### PR DESCRIPTION
I think there is a typo in CsrfScan: there is no `session.secure_cookie` option, maybe you want to reference `session.secure`?