### PR TITLE
chore: add CODEOWNERS file for automatic pull request assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file allows automatic assignment of pull requests.
+# See https://help.github.com/articles/about-codeowners/
+
+* @leonardo403


### PR DESCRIPTION
Hi @leonardo403!

I am suggesting the addition of a `CODEOWNERS` file to automate the project's code review workflow. 

With this configuration, GitHub will automatically assign you as a reviewer for any new Pull Requests opened by external contributors. This will help streamline project management and ensure that no changes are merged without your review and approval.